### PR TITLE
added request body template for question and user input parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,13 +28,7 @@ type Question = {
 	answer: string;
 	favourited: boolean;
 	timestamp: string;
-};
-
-// query params template
-type UserInput = {
-	difficulty: 'easy' | 'medium' | 'hard';
-	category: string;
-	numberQus: number;
+	numberQus?: number; //number of questions determined by user query but not in library
 };
 
 //get endpoint setion

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,25 @@ const readData = async () => {
 	});
 };
 
+// request body template
+type Question = {
+	id: number;
+	category: string;
+	difficulty: 'easy' | 'medium' | 'hard';
+	question: string;
+	options: string[];
+	answer: string;
+	favourited: boolean;
+	timestamp: string;
+};
+
+// query params template
+type UserInput = {
+	difficulty: 'easy' | 'medium' | 'hard';
+	category: string;
+	numberQus: number;
+};
+
 //get endpoint setion
 app.get('/', (req: Request, res: Response) => {
 	readData();


### PR DESCRIPTION
Relates #7

I've created templates for the question request body and the user input query parameters. I'm not sure if we need both but I thought we needed a template to handle the input requesting number of questions from the user in addition to the question. But the user input is a bit repetitive.

```ts
// request body template
type Question = {
	id: number;
	category: string;
	difficulty: 'easy' | 'medium' | 'hard';
	question: string;
	options: string[];
	answer: string;
	favourited: boolean;
	timestamp: string;
};

// query params template
type UserInput = {
	difficulty: 'easy' | 'medium' | 'hard';
	category: string;
	numberQus: number;
};
```